### PR TITLE
Fix f130/f240 logic for simplified language editions

### DIFF
--- a/src/transform/generators/common/generate-1xx-common.js
+++ b/src/transform/generators/common/generate-1xx-common.js
@@ -80,11 +80,12 @@ export function generate110Common(_onixConversionConfiguration, valueInterface) 
 
 /**
  * Generates 130 field for print and electronical records if Title with TitleType value of 03 is found.
- * Field is not generated for simplified language editions or if main author is defined.
+ * Field is not generated if main author is defined.
  * @param {import('../../../types.js').OnixConversionConfiguration} onixConversionConfiguration - configuration for ONIX->MARC21 conversion
  * @param {import('../../../types.js').ValueInterface} valueInterface ValueInterface containing getValue/getValues functions
  * @returns {import('../../../types.js').DataField[]} Array containing field 130
  */
+// eslint-disable-next-line max-lines-per-function
 export function generate130Common(onixConversionConfiguration, valueInterface) {
   /*
   Onix Codelists: List 15: TitleType
@@ -128,10 +129,20 @@ export function generate130Common(onixConversionConfiguration, valueInterface) {
   // Generate language subfield only if exactly one language is observed
   const languages = getRecordMainLangs(valueInterface, languageSanityCheck);
   const translatedLanguage = languages.length === 1 ? translateLanguageCode(languages[0]) : null;
-  const languageSubfield = translatedLanguage ? [{code: 'l', value: `${translatedLanguage}.`}] : [];
 
-  // For SMP editions, an additional $s is created
-  const subfieldS = isSimplifiedLanguageEdition(valueInterface) ? [{code: 's', value: '(selkokieli)'}] : [];
+  // $l and $s are dependent on whether entry is simplified language edition or not
+  let subfieldS = [];
+  let subfieldLValue = translatedLanguage ? `${translatedLanguage}` : '';
+
+  if (isSimplifiedLanguageEdition(valueInterface)) {
+    subfieldLValue += ' (selkokieli)';
+
+    const subfieldSValue = getSubfieldSValue(valueInterface);
+    subfieldS = subfieldSValue ? [{code: 's', value: subfieldSValue}] : [];
+  }
+
+  const subfieldLSeparator = subfieldLValue.endsWith(')') ? '' : '.';
+  const subfieldL = subfieldLValue.length > 0 ? [{code: 'l', value: `${subfieldLValue.trim()}${subfieldLSeparator}`}] : [];
 
   // Note: ind1 is set by validator
 
@@ -140,10 +151,40 @@ export function generate130Common(onixConversionConfiguration, valueInterface) {
       tag: '130',
       subfields: [
         {code: 'a', value: `${unifiedTitleText}.`},
-        ...languageSubfield,
+        ...subfieldL,
         ...subfieldS
       ]
     }
   ];
+
+
+  function getSubfieldSValue(valueInterface) {
+    const {contributors} = getContributors(valueInterface);
+    const sleContributors = contributors.filter(a => a.roleCodes.includes('B05'));
+    const sleSurnames = sleContributors
+      .map(a => {
+        const personNameInverted = a.personNameInverted;
+        if (!personNameInverted) {
+          return null;
+        }
+
+        return personNameInverted.split(',')[0];
+      })
+      .filter(v => typeof v === 'string' && v.length > 0);
+
+    if (sleSurnames.length === 0) {
+      return null;
+    }
+
+    if (sleSurnames.length === 1) {
+      return `(${sleSurnames[0]})`;
+    }
+
+    if (sleSurnames.length === 2) {
+      return `(${sleSurnames[0]} ja ${sleSurnames[1]})`;
+    }
+
+    return `(${sleSurnames[0]} ja muita)`;
+  }
 }
 

--- a/src/transform/generators/common/generate-2xx-common.js
+++ b/src/transform/generators/common/generate-2xx-common.js
@@ -141,9 +141,9 @@ export function generate245Common(onixConversionConfiguration, valueInterface) {
     throw new Error('Could not generate field 245 due to missing title information');
   }
 
-  // Post processing of title
+  // Post processing of title for only f245
   const stripTitleRegexp = [
-    /\(selkokirja\)$/ui
+    /\(selkokirja\)$/ui,
   ];
 
   const processedTitle = stripTitleRegexp.reduce((p, n) => p.replace(n, ''), title).trim();

--- a/src/transform/generators/common/generate-2xx-common.js
+++ b/src/transform/generators/common/generate-2xx-common.js
@@ -6,11 +6,12 @@ import {generate130Common} from './generate-1xx-common.js';
 
 /**
  * Generates 240 field for print and electronical records if title with TitleType value of 03 is found.
- * Field is not generated for simplified language editions or if main author is not defined.
+ * Field is not generated if main author is not defined.
  * @param {import('../../../types.js').OnixConversionConfiguration} onixConversionConfiguration - configuration for ONIX->MARC21 conversion
  * @param {import('../../../types.js').ValueInterface} valueInterface ValueInterface containing getValue/getValues functions
  * @returns {import('../../../types.js').DataField[]} Array containing field 240
  */
+// eslint-disable-next-line max-lines-per-function
 export function generate240Common(onixConversionConfiguration, valueInterface) {
   /*
   Onix Codelists: List 15: TitleType
@@ -54,10 +55,20 @@ export function generate240Common(onixConversionConfiguration, valueInterface) {
   // Generate language subfield only if exactly one language is observed
   const languages = getRecordMainLangs(valueInterface, languageSanityCheck);
   const translatedLanguage = languages.length === 1 ? translateLanguageCode(languages[0]) : null;
-  const languageSubfield = translatedLanguage ? [{code: 'l', value: `${translatedLanguage}`}] : [];
 
-  // For SMP editions, an additional $s is created
-  const subfieldS = isSimplifiedLanguageEdition(valueInterface) ? [{code: 's', value: '(selkokieli)'}] : [];
+
+  // $l and $s are dependent on whether entry is simplified language edition or not
+  let subfieldS = [];
+  let subfieldLValue = translatedLanguage ? `${translatedLanguage}` : '';
+
+  if (isSimplifiedLanguageEdition(valueInterface)) {
+    subfieldLValue += ' (selkokieli)';
+
+    const subfieldSValue = getSubfieldSValue(valueInterface);
+    subfieldS = subfieldSValue ? [{code: 's', value: subfieldSValue}] : [];
+  }
+
+  const subfieldL = subfieldLValue.length > 0 ? [{code: 'l', value: `${subfieldLValue.trim()}`}] : [];
 
   // Note: ind2 is set by validator
 
@@ -67,11 +78,43 @@ export function generate240Common(onixConversionConfiguration, valueInterface) {
       ind1: '1',
       subfields: [
         {code: 'a', value: `${unifiedTitleText}.`},
-        ...languageSubfield,
+        ...subfieldL,
         ...subfieldS
       ]
     }
   ];
+
+
+  function getSubfieldSValue(valueInterface) {
+    const {mainAuthor, contributors} = getContributors(valueInterface);
+    const sleContributors = [mainAuthor, ...contributors]
+      .filter(a => a && a.personNameInverted && a.roleCodes.includes('B05'));
+
+    const sleSurnames = sleContributors
+      .map(a => {
+        const personNameInverted = a.personNameInverted;
+        if (!personNameInverted) {
+          return null;
+        }
+
+        return personNameInverted.split(',')[0];
+      })
+      .filter(v => typeof v === 'string' && v.length > 0);
+
+    if (sleSurnames.length === 0) {
+      return null;
+    }
+
+    if (sleSurnames.length === 1) {
+      return `(${sleSurnames[0]})`;
+    }
+
+    if (sleSurnames.length === 2) {
+      return `(${sleSurnames[0]} ja ${sleSurnames[1]})`;
+    }
+
+    return `(${sleSurnames[0]} ja muita)`;
+  }
 }
 
 /**

--- a/src/transform/generators/common/generate-2xx-common.js
+++ b/src/transform/generators/common/generate-2xx-common.js
@@ -141,13 +141,20 @@ export function generate245Common(onixConversionConfiguration, valueInterface) {
     throw new Error('Could not generate field 245 due to missing title information');
   }
 
+  // Post processing of title
+  const stripTitleRegexp = [
+    /\(selkokirja\)$/ui
+  ];
+
+  const processedTitle = stripTitleRegexp.reduce((p, n) => p.replace(n, ''), title).trim();
+
   if (subtitle) {
     return [
       {
         tag: '245',
         ind1,
         subfields: [
-          {code: 'a', value: `${title} :`},
+          {code: 'a', value: `${processedTitle} :`},
           {code: 'b', value: subtitle}
         ]
       }
@@ -159,7 +166,7 @@ export function generate245Common(onixConversionConfiguration, valueInterface) {
       tag: '245',
       ind1,
       subfields: [
-        {code: 'a', value: `${title}.`}
+        {code: 'a', value: `${processedTitle}.`}
       ]
     }
   ];

--- a/src/transform/record-utils.js
+++ b/src/transform/record-utils.js
@@ -758,16 +758,23 @@ export function getTitle(valueInterface, useSplitRules = true) {
     throw new Error(`Title ${titleText} was observed to be a serial title. Refusing to process further.`);
   }
 
+  // Processing of title that should always be applied no matter the context
+  const stripTitleRegexp = [
+    /^(POISTETTU MYYNNISTÄ|PERUTTU|EI ILMESTY)/u,
+  ];
+
+  const processedTitleText = stripTitleRegexp.reduce((p, n) => p.replace(n, ''), titleText).trim();
+
   if (!useSplitRules || subtitleText) {
-    return {title: titleText.trim(), subtitle: subtitleText ? subtitleText.trim() : null};
+    return {title: processedTitleText, subtitle: subtitleText ? subtitleText.trim() : null};
   }
 
   // Check whether title contains characters where a split between title and subtitle could be observed
-  const titleSplitRegex = findTitleSplitRegex(titleText);
-  const {alternativeTitle, alternativeSubtitle} = splitTitle(titleText, titleSplitRegex);
+  const titleSplitRegex = findTitleSplitRegex(processedTitleText);
+  const {alternativeTitle, alternativeSubtitle} = splitTitle(processedTitleText, titleSplitRegex);
 
   if (!alternativeTitle) {
-    return {title: titleText.trim(), subtitle: null};
+    return {title: processedTitleText, subtitle: null};
   }
 
   return {

--- a/test-fixtures/transform/generators/common/generate-1xx-common/generate-130-common/05/metadata.json
+++ b/test-fixtures/transform/generators/common/generate-1xx-common/generate-130-common/05/metadata.json
@@ -1,5 +1,5 @@
 {
-  "description": "Return empty array for simplified language editions",
+  "description": "Return proper $l for simplified language editions when language is not observed",
   "onixConversionConfiguration": {
     "languageSanityCheck": false,
     "preventUniformTitleGeneration": false

--- a/test-fixtures/transform/generators/common/generate-1xx-common/generate-130-common/05/output.json
+++ b/test-fixtures/transform/generators/common/generate-1xx-common/generate-130-common/05/output.json
@@ -7,7 +7,7 @@
         "value": "Original title."
       },
       {
-        "code": "s",
+        "code": "l",
         "value": "(selkokieli)"
       }
     ]

--- a/test-fixtures/transform/generators/common/generate-1xx-common/generate-130-common/06/output.json
+++ b/test-fixtures/transform/generators/common/generate-1xx-common/generate-130-common/06/output.json
@@ -7,7 +7,7 @@
         "value": "Original title."
       },
       {
-        "code": "s",
+        "code": "l",
         "value": "(selkokieli)"
       }
     ]

--- a/test-fixtures/transform/generators/common/generate-1xx-common/generate-130-common/12/input.xml
+++ b/test-fixtures/transform/generators/common/generate-1xx-common/generate-130-common/12/input.xml
@@ -1,0 +1,24 @@
+<Product>
+  <DescriptiveDetail>
+    <EditionType>SMP</EditionType>
+
+    <Language>
+      <LanguageRole>01</LanguageRole>
+      <LanguageCode>fin</LanguageCode>
+    </Language>
+
+    <TitleDetail>
+      <TitleType>01</TitleType>
+      <TitleElement>
+        <TitleText>Translated title</TitleText>
+      </TitleElement>
+    </TitleDetail>
+
+    <TitleDetail>
+      <TitleType>03</TitleType>
+      <TitleElement>
+        <TitleText>Original title</TitleText>
+      </TitleElement>
+    </TitleDetail>
+  </DescriptiveDetail>
+</Product>

--- a/test-fixtures/transform/generators/common/generate-1xx-common/generate-130-common/12/metadata.json
+++ b/test-fixtures/transform/generators/common/generate-1xx-common/generate-130-common/12/metadata.json
@@ -1,5 +1,5 @@
 {
-  "description": "Return field properly when simplified language edition is observed from title information",
+  "description": "$l is generated for simplified language editions properly when language is observed",
   "onixConversionConfiguration": {
     "languageSanityCheck": false,
     "preventUniformTitleGeneration": false

--- a/test-fixtures/transform/generators/common/generate-1xx-common/generate-130-common/12/output.json
+++ b/test-fixtures/transform/generators/common/generate-1xx-common/generate-130-common/12/output.json
@@ -1,7 +1,6 @@
 [
   {
-    "tag": "240",
-    "ind1": "1",
+    "tag": "130",
     "subfields": [
       {
         "code": "a",
@@ -9,7 +8,7 @@
       },
       {
         "code": "l",
-        "value": "(selkokieli)"
+        "value": "Suomi (selkokieli)"
       }
     ]
   }

--- a/test-fixtures/transform/generators/common/generate-1xx-common/generate-130-common/13/input.xml
+++ b/test-fixtures/transform/generators/common/generate-1xx-common/generate-130-common/13/input.xml
@@ -1,0 +1,31 @@
+<Product>
+  <DescriptiveDetail>
+    <!-- SLE author with B05 role -->
+    <Contributor>
+      <ContributorRole>B05</ContributorRole>
+      <SequenceNumber>1</SequenceNumber>
+      <PersonNameInverted>Baz, Foo</PersonNameInverted>
+    </Contributor>
+
+    <EditionType>SMP</EditionType>
+
+    <Language>
+      <LanguageRole>01</LanguageRole>
+      <LanguageCode>fin</LanguageCode>
+    </Language>
+
+    <TitleDetail>
+      <TitleType>01</TitleType>
+      <TitleElement>
+        <TitleText>Translated title</TitleText>
+      </TitleElement>
+    </TitleDetail>
+
+    <TitleDetail>
+      <TitleType>03</TitleType>
+      <TitleElement>
+        <TitleText>Original title</TitleText>
+      </TitleElement>
+    </TitleDetail>
+  </DescriptiveDetail>
+</Product>

--- a/test-fixtures/transform/generators/common/generate-1xx-common/generate-130-common/13/metadata.json
+++ b/test-fixtures/transform/generators/common/generate-1xx-common/generate-130-common/13/metadata.json
@@ -1,5 +1,5 @@
 {
-  "description": "Return field properly when simplified language edition is observed from title information",
+  "description": "Simplified language authors are properly added to $s",
   "onixConversionConfiguration": {
     "languageSanityCheck": false,
     "preventUniformTitleGeneration": false

--- a/test-fixtures/transform/generators/common/generate-1xx-common/generate-130-common/13/output.json
+++ b/test-fixtures/transform/generators/common/generate-1xx-common/generate-130-common/13/output.json
@@ -1,7 +1,6 @@
 [
   {
-    "tag": "240",
-    "ind1": "1",
+    "tag": "130",
     "subfields": [
       {
         "code": "a",
@@ -9,8 +8,13 @@
       },
       {
         "code": "l",
-        "value": "(selkokieli)"
+        "value": "Suomi (selkokieli)"
+      },
+      {
+        "code": "s",
+        "value": "(Baz)"
       }
+
     ]
   }
 ]

--- a/test-fixtures/transform/generators/common/generate-1xx-common/generate-130-common/14/input.xml
+++ b/test-fixtures/transform/generators/common/generate-1xx-common/generate-130-common/14/input.xml
@@ -1,0 +1,38 @@
+<Product>
+  <DescriptiveDetail>
+    <!-- SLE author with B05 role -->
+    <Contributor>
+      <ContributorRole>B05</ContributorRole>
+      <SequenceNumber>1</SequenceNumber>
+      <PersonNameInverted>Bar, Foo</PersonNameInverted>
+    </Contributor>
+
+    <!-- SLE author with B05 role -->
+    <Contributor>
+      <ContributorRole>B05</ContributorRole>
+      <SequenceNumber>2</SequenceNumber>
+      <PersonNameInverted>Baz, Foo</PersonNameInverted>
+    </Contributor>
+
+    <EditionType>SMP</EditionType>
+
+    <Language>
+      <LanguageRole>01</LanguageRole>
+      <LanguageCode>fin</LanguageCode>
+    </Language>
+
+    <TitleDetail>
+      <TitleType>01</TitleType>
+      <TitleElement>
+        <TitleText>Translated title</TitleText>
+      </TitleElement>
+    </TitleDetail>
+
+    <TitleDetail>
+      <TitleType>03</TitleType>
+      <TitleElement>
+        <TitleText>Original title</TitleText>
+      </TitleElement>
+    </TitleDetail>
+  </DescriptiveDetail>
+</Product>

--- a/test-fixtures/transform/generators/common/generate-1xx-common/generate-130-common/14/metadata.json
+++ b/test-fixtures/transform/generators/common/generate-1xx-common/generate-130-common/14/metadata.json
@@ -1,5 +1,5 @@
 {
-  "description": "Return field properly when simplified language edition is observed from title information",
+  "description": "Simplified language contributors are properly added to $s when there are two contributor with the said role",
   "onixConversionConfiguration": {
     "languageSanityCheck": false,
     "preventUniformTitleGeneration": false

--- a/test-fixtures/transform/generators/common/generate-1xx-common/generate-130-common/14/output.json
+++ b/test-fixtures/transform/generators/common/generate-1xx-common/generate-130-common/14/output.json
@@ -1,7 +1,6 @@
 [
   {
-    "tag": "240",
-    "ind1": "1",
+    "tag": "130",
     "subfields": [
       {
         "code": "a",
@@ -9,8 +8,13 @@
       },
       {
         "code": "l",
-        "value": "(selkokieli)"
+        "value": "Suomi (selkokieli)"
+      },
+      {
+        "code": "s",
+        "value": "(Bar ja Baz)"
       }
+
     ]
   }
 ]

--- a/test-fixtures/transform/generators/common/generate-1xx-common/generate-130-common/15/input.xml
+++ b/test-fixtures/transform/generators/common/generate-1xx-common/generate-130-common/15/input.xml
@@ -1,0 +1,45 @@
+<Product>
+  <DescriptiveDetail>
+    <!-- SLE author with B05 role -->
+    <Contributor>
+      <ContributorRole>B05</ContributorRole>
+      <SequenceNumber>1</SequenceNumber>
+      <PersonNameInverted>Bar, Foo</PersonNameInverted>
+    </Contributor>
+
+    <!-- SLE author with B05 role -->
+    <Contributor>
+      <ContributorRole>B05</ContributorRole>
+      <SequenceNumber>2</SequenceNumber>
+      <PersonNameInverted>Baz, Foo</PersonNameInverted>
+    </Contributor>
+
+    <!-- SLE author with B05 role -->
+    <Contributor>
+      <ContributorRole>B05</ContributorRole>
+      <SequenceNumber>3</SequenceNumber>
+      <PersonNameInverted>Qux, Foo</PersonNameInverted>
+    </Contributor>
+
+    <EditionType>SMP</EditionType>
+
+    <Language>
+      <LanguageRole>01</LanguageRole>
+      <LanguageCode>fin</LanguageCode>
+    </Language>
+
+    <TitleDetail>
+      <TitleType>01</TitleType>
+      <TitleElement>
+        <TitleText>Translated title</TitleText>
+      </TitleElement>
+    </TitleDetail>
+
+    <TitleDetail>
+      <TitleType>03</TitleType>
+      <TitleElement>
+        <TitleText>Original title</TitleText>
+      </TitleElement>
+    </TitleDetail>
+  </DescriptiveDetail>
+</Product>

--- a/test-fixtures/transform/generators/common/generate-1xx-common/generate-130-common/15/metadata.json
+++ b/test-fixtures/transform/generators/common/generate-1xx-common/generate-130-common/15/metadata.json
@@ -1,0 +1,8 @@
+{
+  "description": "Simplified language contributors are properly added to $s when there are more then two contributor with the said role",
+  "onixConversionConfiguration": {
+    "languageSanityCheck": false,
+    "preventUniformTitleGeneration": false
+  },
+  "only": false
+}

--- a/test-fixtures/transform/generators/common/generate-1xx-common/generate-130-common/15/output.json
+++ b/test-fixtures/transform/generators/common/generate-1xx-common/generate-130-common/15/output.json
@@ -1,7 +1,6 @@
 [
   {
-    "tag": "240",
-    "ind1": "1",
+    "tag": "130",
     "subfields": [
       {
         "code": "a",
@@ -9,8 +8,13 @@
       },
       {
         "code": "l",
-        "value": "(selkokieli)"
+        "value": "Suomi (selkokieli)"
+      },
+      {
+        "code": "s",
+        "value": "(Bar ja muita)"
       }
+
     ]
   }
 ]

--- a/test-fixtures/transform/generators/common/generate-2xx-common/generate-240-common/05/metadata.json
+++ b/test-fixtures/transform/generators/common/generate-2xx-common/generate-240-common/05/metadata.json
@@ -1,5 +1,5 @@
 {
-  "description": "Returns empty array for simplified language edition (observed from EditionType)",
+  "description": "Adds $l for simplified language edition (observed from EditionType)",
   "onixConversionConfiguration": {
     "languageSanityCheck": false,
     "preventUniformTitleGeneration": false

--- a/test-fixtures/transform/generators/common/generate-2xx-common/generate-240-common/06/metadata.json
+++ b/test-fixtures/transform/generators/common/generate-2xx-common/generate-240-common/06/metadata.json
@@ -1,5 +1,5 @@
 {
-  "description": "Returns empty array for simplified language edition (observed from title)",
+  "description": "Adds $l for simplified language edition (observed from title)",
   "onixConversionConfiguration": {
     "languageSanityCheck": false,
     "preventUniformTitleGeneration": false

--- a/test-fixtures/transform/generators/common/generate-2xx-common/generate-240-common/06/output.json
+++ b/test-fixtures/transform/generators/common/generate-2xx-common/generate-240-common/06/output.json
@@ -8,7 +8,7 @@
         "value": "Original title."
       },
       {
-        "code": "s",
+        "code": "l",
         "value": "(selkokieli)"
       }
     ]

--- a/test-fixtures/transform/generators/common/generate-2xx-common/generate-240-common/11/input.xml
+++ b/test-fixtures/transform/generators/common/generate-2xx-common/generate-240-common/11/input.xml
@@ -1,0 +1,31 @@
+<Product>
+  <DescriptiveDetail>
+    <EditionType>SMP</EditionType>
+
+    <!-- Main author -->
+    <Contributor>
+      <ContributorRole>A01</ContributorRole>
+      <SequenceNumber>1</SequenceNumber>
+      <PersonNameInverted>Bar, Foo</PersonNameInverted>
+    </Contributor>
+
+    <Language>
+      <LanguageRole>01</LanguageRole>
+      <LanguageCode>fin</LanguageCode>
+    </Language>
+
+    <TitleDetail>
+      <TitleType>01</TitleType>
+      <TitleElement>
+        <TitleText>Translated title</TitleText>
+      </TitleElement>
+    </TitleDetail>
+
+    <TitleDetail>
+      <TitleType>03</TitleType>
+      <TitleElement>
+        <TitleText>Original title</TitleText>
+      </TitleElement>
+    </TitleDetail>
+  </DescriptiveDetail>
+</Product>

--- a/test-fixtures/transform/generators/common/generate-2xx-common/generate-240-common/11/metadata.json
+++ b/test-fixtures/transform/generators/common/generate-2xx-common/generate-240-common/11/metadata.json
@@ -1,5 +1,5 @@
 {
-  "description": "Return field properly when simplified language edition is observed from title information",
+  "description": "$l is formatted properly when language is observed and entry is simplified language edition",
   "onixConversionConfiguration": {
     "languageSanityCheck": false,
     "preventUniformTitleGeneration": false

--- a/test-fixtures/transform/generators/common/generate-2xx-common/generate-240-common/11/output.json
+++ b/test-fixtures/transform/generators/common/generate-2xx-common/generate-240-common/11/output.json
@@ -9,7 +9,7 @@
       },
       {
         "code": "l",
-        "value": "(selkokieli)"
+        "value": "Suomi (selkokieli)"
       }
     ]
   }

--- a/test-fixtures/transform/generators/common/generate-2xx-common/generate-240-common/12/input.xml
+++ b/test-fixtures/transform/generators/common/generate-2xx-common/generate-240-common/12/input.xml
@@ -1,0 +1,38 @@
+<Product>
+  <DescriptiveDetail>
+    <EditionType>SMP</EditionType>
+
+    <!-- Main author -->
+    <Contributor>
+      <ContributorRole>A01</ContributorRole>
+      <SequenceNumber>1</SequenceNumber>
+      <PersonNameInverted>Bar, Foo</PersonNameInverted>
+    </Contributor>
+
+    <!-- Main author - additional role -->
+    <Contributor>
+      <ContributorRole>B05</ContributorRole>
+      <SequenceNumber>2</SequenceNumber>
+      <PersonNameInverted>Bar, Foo</PersonNameInverted>
+    </Contributor>
+
+    <Language>
+      <LanguageRole>01</LanguageRole>
+      <LanguageCode>fin</LanguageCode>
+    </Language>
+
+    <TitleDetail>
+      <TitleType>01</TitleType>
+      <TitleElement>
+        <TitleText>Translated title</TitleText>
+      </TitleElement>
+    </TitleDetail>
+
+    <TitleDetail>
+      <TitleType>03</TitleType>
+      <TitleElement>
+        <TitleText>Original title</TitleText>
+      </TitleElement>
+    </TitleDetail>
+  </DescriptiveDetail>
+</Product>

--- a/test-fixtures/transform/generators/common/generate-2xx-common/generate-240-common/12/metadata.json
+++ b/test-fixtures/transform/generators/common/generate-2xx-common/generate-240-common/12/metadata.json
@@ -1,5 +1,5 @@
 {
-  "description": "Return field properly when simplified language edition is observed from title information",
+  "description": "Adds proper $s when one author is found with B05 role",
   "onixConversionConfiguration": {
     "languageSanityCheck": false,
     "preventUniformTitleGeneration": false

--- a/test-fixtures/transform/generators/common/generate-2xx-common/generate-240-common/12/output.json
+++ b/test-fixtures/transform/generators/common/generate-2xx-common/generate-240-common/12/output.json
@@ -9,7 +9,11 @@
       },
       {
         "code": "l",
-        "value": "(selkokieli)"
+        "value": "Suomi (selkokieli)"
+      },
+      {
+        "code": "s",
+        "value": "(Bar)"
       }
     ]
   }

--- a/test-fixtures/transform/generators/common/generate-2xx-common/generate-240-common/13/input.xml
+++ b/test-fixtures/transform/generators/common/generate-2xx-common/generate-240-common/13/input.xml
@@ -1,0 +1,45 @@
+<Product>
+  <DescriptiveDetail>
+    <EditionType>SMP</EditionType>
+
+    <!-- Main author -->
+    <Contributor>
+      <ContributorRole>A01</ContributorRole>
+      <SequenceNumber>1</SequenceNumber>
+      <PersonNameInverted>Bar, Foo</PersonNameInverted>
+    </Contributor>
+
+    <!-- Main author - additional role -->
+    <Contributor>
+      <ContributorRole>B05</ContributorRole>
+      <SequenceNumber>2</SequenceNumber>
+      <PersonNameInverted>Bar, Foo</PersonNameInverted>
+    </Contributor>
+
+    <!-- Contributor for simplified language edition -->
+    <Contributor>
+      <ContributorRole>B05</ContributorRole>
+      <SequenceNumber>3</SequenceNumber>
+      <PersonNameInverted>Baz, Foo</PersonNameInverted>
+    </Contributor>
+
+    <Language>
+      <LanguageRole>01</LanguageRole>
+      <LanguageCode>fin</LanguageCode>
+    </Language>
+
+    <TitleDetail>
+      <TitleType>01</TitleType>
+      <TitleElement>
+        <TitleText>Translated title</TitleText>
+      </TitleElement>
+    </TitleDetail>
+
+    <TitleDetail>
+      <TitleType>03</TitleType>
+      <TitleElement>
+        <TitleText>Original title</TitleText>
+      </TitleElement>
+    </TitleDetail>
+  </DescriptiveDetail>
+</Product>

--- a/test-fixtures/transform/generators/common/generate-2xx-common/generate-240-common/13/metadata.json
+++ b/test-fixtures/transform/generators/common/generate-2xx-common/generate-240-common/13/metadata.json
@@ -1,5 +1,5 @@
 {
-  "description": "Return field properly when simplified language edition is observed from title information",
+  "description": "Adds proper $s when two authors are found with B05 role",
   "onixConversionConfiguration": {
     "languageSanityCheck": false,
     "preventUniformTitleGeneration": false

--- a/test-fixtures/transform/generators/common/generate-2xx-common/generate-240-common/13/output.json
+++ b/test-fixtures/transform/generators/common/generate-2xx-common/generate-240-common/13/output.json
@@ -9,7 +9,11 @@
       },
       {
         "code": "l",
-        "value": "(selkokieli)"
+        "value": "Suomi (selkokieli)"
+      },
+      {
+        "code": "s",
+        "value": "(Bar ja Baz)"
       }
     ]
   }

--- a/test-fixtures/transform/generators/common/generate-2xx-common/generate-240-common/14/input.xml
+++ b/test-fixtures/transform/generators/common/generate-2xx-common/generate-240-common/14/input.xml
@@ -1,0 +1,52 @@
+<Product>
+  <DescriptiveDetail>
+    <EditionType>SMP</EditionType>
+
+    <!-- Main author -->
+    <Contributor>
+      <ContributorRole>A01</ContributorRole>
+      <SequenceNumber>1</SequenceNumber>
+      <PersonNameInverted>Bar, Foo</PersonNameInverted>
+    </Contributor>
+
+    <!-- Main author - additional role -->
+    <Contributor>
+      <ContributorRole>B05</ContributorRole>
+      <SequenceNumber>2</SequenceNumber>
+      <PersonNameInverted>Bar, Foo</PersonNameInverted>
+    </Contributor>
+
+    <!-- Contributor for simplified language edition -->
+    <Contributor>
+      <ContributorRole>B05</ContributorRole>
+      <SequenceNumber>3</SequenceNumber>
+      <PersonNameInverted>Baz, Foo</PersonNameInverted>
+    </Contributor>
+
+    <!-- Contributor for simplified language edition -->
+    <Contributor>
+      <ContributorRole>B05</ContributorRole>
+      <SequenceNumber>4</SequenceNumber>
+      <PersonNameInverted>Qux, Foo</PersonNameInverted>
+    </Contributor>
+
+    <Language>
+      <LanguageRole>01</LanguageRole>
+      <LanguageCode>fin</LanguageCode>
+    </Language>
+
+    <TitleDetail>
+      <TitleType>01</TitleType>
+      <TitleElement>
+        <TitleText>Translated title</TitleText>
+      </TitleElement>
+    </TitleDetail>
+
+    <TitleDetail>
+      <TitleType>03</TitleType>
+      <TitleElement>
+        <TitleText>Original title</TitleText>
+      </TitleElement>
+    </TitleDetail>
+  </DescriptiveDetail>
+</Product>

--- a/test-fixtures/transform/generators/common/generate-2xx-common/generate-240-common/14/metadata.json
+++ b/test-fixtures/transform/generators/common/generate-2xx-common/generate-240-common/14/metadata.json
@@ -1,5 +1,5 @@
 {
-  "description": "Return field properly when simplified language edition is observed from title information",
+  "description": "Adds proper $s when three or more authors are found with B05 role",
   "onixConversionConfiguration": {
     "languageSanityCheck": false,
     "preventUniformTitleGeneration": false

--- a/test-fixtures/transform/generators/common/generate-2xx-common/generate-240-common/14/output.json
+++ b/test-fixtures/transform/generators/common/generate-2xx-common/generate-240-common/14/output.json
@@ -9,7 +9,11 @@
       },
       {
         "code": "l",
-        "value": "(selkokieli)"
+        "value": "Suomi (selkokieli)"
+      },
+      {
+        "code": "s",
+        "value": "(Bar ja muita)"
       }
     ]
   }

--- a/test-fixtures/transform/generators/common/generate-2xx-common/generate-245-common/09/input.xml
+++ b/test-fixtures/transform/generators/common/generate-2xx-common/generate-245-common/09/input.xml
@@ -1,0 +1,13 @@
+<Product>
+  <DescriptiveDetail>
+
+    <TitleDetail>
+      <TitleType>00</TitleType>
+      <TitleElement>
+        <TitleText>Foo (selkokirja)</TitleText>
+        <Subtitle>Bar</Subtitle>
+      </TitleElement>
+    </TitleDetail>
+
+  </DescriptiveDetail>
+</Product>

--- a/test-fixtures/transform/generators/common/generate-2xx-common/generate-245-common/09/metadata.json
+++ b/test-fixtures/transform/generators/common/generate-2xx-common/generate-245-common/09/metadata.json
@@ -1,0 +1,8 @@
+{
+  "description": "Strip (selkokirja) from end of title",
+  "onixConversionConfiguration": {
+    "preventUniformTitleGeneration": false,
+    "languageSanityCheck": false
+  },
+  "only": false
+}

--- a/test-fixtures/transform/generators/common/generate-2xx-common/generate-245-common/09/output.json
+++ b/test-fixtures/transform/generators/common/generate-2xx-common/generate-245-common/09/output.json
@@ -1,0 +1,16 @@
+[
+  {
+    "tag": "245",
+    "ind1": "0",
+    "subfields": [
+      {
+        "code": "a",
+        "value": "Foo :"
+      },
+      {
+        "code": "b",
+        "value": "Bar"
+      }
+    ]
+  }
+]

--- a/test-fixtures/transform/generators/common/generate-2xx-common/generate-245-common/10/input.xml
+++ b/test-fixtures/transform/generators/common/generate-2xx-common/generate-245-common/10/input.xml
@@ -1,0 +1,13 @@
+<Product>
+  <DescriptiveDetail>
+
+    <TitleDetail>
+      <TitleType>00</TitleType>
+      <TitleElement>
+        <TitleText>Foo (Selkokirja)</TitleText>
+        <Subtitle>Bar</Subtitle>
+      </TitleElement>
+    </TitleDetail>
+
+  </DescriptiveDetail>
+</Product>

--- a/test-fixtures/transform/generators/common/generate-2xx-common/generate-245-common/10/metadata.json
+++ b/test-fixtures/transform/generators/common/generate-2xx-common/generate-245-common/10/metadata.json
@@ -1,0 +1,8 @@
+{
+  "description": "Strip (Selkokirja) from end of title",
+  "onixConversionConfiguration": {
+    "preventUniformTitleGeneration": false,
+    "languageSanityCheck": false
+  },
+  "only": false
+}

--- a/test-fixtures/transform/generators/common/generate-2xx-common/generate-245-common/10/output.json
+++ b/test-fixtures/transform/generators/common/generate-2xx-common/generate-245-common/10/output.json
@@ -1,0 +1,16 @@
+[
+  {
+    "tag": "245",
+    "ind1": "0",
+    "subfields": [
+      {
+        "code": "a",
+        "value": "Foo :"
+      },
+      {
+        "code": "b",
+        "value": "Bar"
+      }
+    ]
+  }
+]

--- a/test-fixtures/transform/generators/common/generate-2xx-common/generate-245-common/11/input.xml
+++ b/test-fixtures/transform/generators/common/generate-2xx-common/generate-245-common/11/input.xml
@@ -1,0 +1,13 @@
+<Product>
+  <DescriptiveDetail>
+
+    <TitleDetail>
+      <TitleType>00</TitleType>
+      <TitleElement>
+        <TitleText>POISTETTU MYYNNISTÄ Foo</TitleText>
+        <Subtitle>Bar</Subtitle>
+      </TitleElement>
+    </TitleDetail>
+
+  </DescriptiveDetail>
+</Product>

--- a/test-fixtures/transform/generators/common/generate-2xx-common/generate-245-common/11/metadata.json
+++ b/test-fixtures/transform/generators/common/generate-2xx-common/generate-245-common/11/metadata.json
@@ -1,0 +1,8 @@
+{
+  "description": "Strip POISTETTU MYYNNISTÄ from start of title",
+  "onixConversionConfiguration": {
+    "preventUniformTitleGeneration": false,
+    "languageSanityCheck": false
+  },
+  "only": false
+}

--- a/test-fixtures/transform/generators/common/generate-2xx-common/generate-245-common/11/output.json
+++ b/test-fixtures/transform/generators/common/generate-2xx-common/generate-245-common/11/output.json
@@ -1,0 +1,16 @@
+[
+  {
+    "tag": "245",
+    "ind1": "0",
+    "subfields": [
+      {
+        "code": "a",
+        "value": "Foo :"
+      },
+      {
+        "code": "b",
+        "value": "Bar"
+      }
+    ]
+  }
+]

--- a/test-fixtures/transform/generators/common/generate-2xx-common/generate-245-common/12/input.xml
+++ b/test-fixtures/transform/generators/common/generate-2xx-common/generate-245-common/12/input.xml
@@ -1,0 +1,13 @@
+<Product>
+  <DescriptiveDetail>
+
+    <TitleDetail>
+      <TitleType>00</TitleType>
+      <TitleElement>
+        <TitleText>PERUTTU Foo</TitleText>
+        <Subtitle>Bar</Subtitle>
+      </TitleElement>
+    </TitleDetail>
+
+  </DescriptiveDetail>
+</Product>

--- a/test-fixtures/transform/generators/common/generate-2xx-common/generate-245-common/12/metadata.json
+++ b/test-fixtures/transform/generators/common/generate-2xx-common/generate-245-common/12/metadata.json
@@ -1,0 +1,8 @@
+{
+  "description": "Strip PERUTTU from start of title",
+  "onixConversionConfiguration": {
+    "preventUniformTitleGeneration": false,
+    "languageSanityCheck": false
+  },
+  "only": false
+}

--- a/test-fixtures/transform/generators/common/generate-2xx-common/generate-245-common/12/output.json
+++ b/test-fixtures/transform/generators/common/generate-2xx-common/generate-245-common/12/output.json
@@ -1,0 +1,16 @@
+[
+  {
+    "tag": "245",
+    "ind1": "0",
+    "subfields": [
+      {
+        "code": "a",
+        "value": "Foo :"
+      },
+      {
+        "code": "b",
+        "value": "Bar"
+      }
+    ]
+  }
+]

--- a/test-fixtures/transform/generators/common/generate-2xx-common/generate-245-common/13/input.xml
+++ b/test-fixtures/transform/generators/common/generate-2xx-common/generate-245-common/13/input.xml
@@ -1,0 +1,13 @@
+<Product>
+  <DescriptiveDetail>
+
+    <TitleDetail>
+      <TitleType>00</TitleType>
+      <TitleElement>
+        <TitleText>EI ILMESTY Foo</TitleText>
+        <Subtitle>Bar</Subtitle>
+      </TitleElement>
+    </TitleDetail>
+
+  </DescriptiveDetail>
+</Product>

--- a/test-fixtures/transform/generators/common/generate-2xx-common/generate-245-common/13/metadata.json
+++ b/test-fixtures/transform/generators/common/generate-2xx-common/generate-245-common/13/metadata.json
@@ -1,0 +1,8 @@
+{
+  "description": "Strip EI ILMESTY from start of title",
+  "onixConversionConfiguration": {
+    "preventUniformTitleGeneration": false,
+    "languageSanityCheck": false
+  },
+  "only": false
+}

--- a/test-fixtures/transform/generators/common/generate-2xx-common/generate-245-common/13/output.json
+++ b/test-fixtures/transform/generators/common/generate-2xx-common/generate-245-common/13/output.json
@@ -1,0 +1,16 @@
+[
+  {
+    "tag": "245",
+    "ind1": "0",
+    "subfields": [
+      {
+        "code": "a",
+        "value": "Foo :"
+      },
+      {
+        "code": "b",
+        "value": "Bar"
+      }
+    ]
+  }
+]


### PR DESCRIPTION
For f130/f240 generators:
* Language information for simplified language editions is moved from $s to $l
* $s now contains surnames of contributors having role code of B05

For f245 generator:
* Post-process title so that "(selkokirja)" is not included to $a (case-insensitive)

For title getter:
* Process title so that commonly occurring phrases referring to item state are removed (e.g., POISTETTU MYYNNISTÄ)